### PR TITLE
Fix FASA Trans-stage engine plume

### DIFF
--- a/GameData/RealismOverhaul/RealPlume_Configs/FASA/FASAGeminiLFECentarTwin.cfg
+++ b/GameData/RealismOverhaul/RealPlume_Configs/FASA/FASAGeminiLFECentarTwin.cfg
@@ -15,10 +15,13 @@
         name = Hypergolic-OMS-White
         transformName = thrustTransform
         localRotation = 0,0,0
-        localPosition = 0,0,-0.8
-        fixedScale = 3.54
+        localPosition = 0,0,0
+        fixedScale = 1.0
         energy = 1.5
         speed = 1.5
+        plumePosition = 0,0,-1.0
+        plumeScale = 1.0
+        flarePosition = 0,0,-0.7
+        flareScale = 0.5
     }
 }
-


### PR DESCRIPTION
A number of FASA hypergolic plumes got borked at some point. This one was still broken. Tested in game, moves and scales the plumes to look good, not make the craft appear to be on hypergolic-fire.